### PR TITLE
API Limit Result Section

### DIFF
--- a/cuckoo/cuckooresult.py
+++ b/cuckoo/cuckooresult.py
@@ -204,7 +204,7 @@ def process_behaviour(behaviour: dict, al_result: Result, process_map: dict, sys
             if pid_api_sums > num_process_calls:
                 limited_calls_table.append({
                     "name": process["process_name"],
-                    "api_calls_made_in_detonation": pid_api_sums,
+                    "api_calls_made_during_detonation": pid_api_sums,
                     "api_calls_included_in_report": num_process_calls
                 })
 

--- a/cuckoo/signatures.py
+++ b/cuckoo/signatures.py
@@ -525,7 +525,8 @@ CUCKOO_SIGNATURES = {
   "network_http": "C2",
   "process_needed": "Suspicious Execution Chain",
   "winmgmts_process_create": "WMI",
-  "dll_load_uncommon_file_types": "Suspicious DLL"
+  "dll_load_uncommon_file_types": "Suspicious DLL",
+  "api_hammering": "Anti-sandbox"
 }
 
 CUCKOO_SIGNATURE_CATEGORIES = {


### PR DESCRIPTION
Adding a result section that lets the analyst know that the api calls in report.json have been limited.

The Cuckoo service adaptation for the following tickets: https://cccs.atlassian.net/browse/AL-560, https://cccs.atlassian.net/browse/AL-883

Related Cuckoo-side modifications are here: https://github.com/cuckoosandbox/community/pull/484, https://github.com/cuckoosandbox/cuckoo/pull/3137