### PR TITLE
Changed source of file name

### DIFF
--- a/cuckoo/cuckoo.py
+++ b/cuckoo/cuckoo.py
@@ -215,7 +215,7 @@ class Cuckoo(ServiceBase):
         self.file_res = request.result
         file_content = request.file_contents
         self.cuckoo_task = None
-        self.file_name = os.path.basename(request.file_name)
+        self.file_name = os.path.basename(request.task.file_name)
 
         # Check the filename to see if it's mime encoded
         mime_re = re.compile(r"^=\?.*\?=$")


### PR DESCRIPTION
Changing source of file name from potentially a SHA256 -> the original file name. 
The original name of the file submitted is actually very important for dynamic analysis, as a common anti-sandbox technique is to check if the file's name is how it would appear in the wild.

Closes https://cccs.atlassian.net/browse/AL-909