### PR TITLE
🐦 

### DIFF
--- a/cuckoo/cuckoo.py
+++ b/cuckoo/cuckoo.py
@@ -1358,7 +1358,7 @@ class Cuckoo(ServiceBase):
         # This method will be used to determine the host to use for a submission
         # Key aspect that we are using to make a decision is the # of pending tasks, aka the queue size
         host_details = []
-        max_queue_size = 0
+        min_queue_size = 9999999999
         for host in hosts:
             host_status_url = f"http://{host['remote_host_ip']}:{host['remote_host_port']}/{CUCKOO_API_QUERY_HOST}"
             try:
@@ -1373,12 +1373,12 @@ class Cuckoo(ServiceBase):
                 resp_dict = resp.json()
                 queue_size = resp_dict["tasks"]["pending"]
                 host_details.append((host, queue_size))
-                if queue_size > max_queue_size:
-                    max_queue_size = queue_size
+                if queue_size < min_queue_size:
+                    min_queue_size = queue_size
 
         for host_detail in host_details:
             host, queue_size = host_detail
-            if queue_size == max_queue_size:
+            if queue_size == min_queue_size:
                 return host
 
         raise CuckooVMBusyException(f"No host available for submission between {[host['remote_host_ip'] for host in hosts]}")

--- a/cuckoo/safelist.py
+++ b/cuckoo/safelist.py
@@ -55,6 +55,9 @@ SAFELIST_DOMAINS = {
     # Omniroot
     'Omniroot': r'ocsp\.omniroot\.com$',
 
+    # WPAD
+    'WPAD': r'^wpad\..*$',
+
     # Microsoft
     'Schemas': r'schemas\.microsoft\.com$',
     'Microsoft IPv4To6': r'.*\.?teredo\.ipv6\.microsoft\.com$',
@@ -85,6 +88,8 @@ SAFELIST_DOMAINS = {
     'Internet Explorer': r'iecvlist\.microsoft\.com$',
     'Internet Explorer Too': r'r20swj13mr\.microsoft\.com$',
     'Microsoft Edge': r'(([a-z]-ring(-fallback)?)|(fp)|(segments-[a-z]))\.msedge\.net$',
+    'Microsoft Store': r'displaycatalog\.md\.mp\.microsoft\.com$',
+    'Office Client': r'officeclient\.microsoft\.com$',
 
     # Windows
     'Windows Settings': r'settings-win\.data\.microsoft\.com$',
@@ -131,12 +136,8 @@ SAFELIST_DOMAINS = {
     'Verisign General CRL': 'crl\.verisign\.com$',
 
     # Ubuntu
-    'Ubuntu Update': r'changelogs\.ubuntu\.com$',
-    'Ubuntu Netmon': r'daisy\.ubuntu\.com$',
-    'Ubuntu NTP': r'ntp\.ubuntu\.com$',
-    'Ubuntu DDebs': r'ddebs\.ubuntu\.com$',
-    'Azure Ubuntu': r'azure\.archive\.ubuntu\.com$',
-    'Security Ubuntu': r'security\.ubuntu\.com$',
+    'Ubuntu Update': r'(changelogs|daisy|ntp|ddebs|security)\.ubuntu\.com$',
+    'Archive Ubuntu': r'(azure|ca)\.archive\.ubuntu\.com$',
 
     # Local
     'TCP Local': r'.*\.local$',
@@ -178,11 +179,12 @@ SAFELIST_DOMAINS = {
 SAFELIST_IPS = {
     'Public DNS': r'(^1\.1\.1\.1$)|(^8\.8\.8\.8$)',
     'Local': r'(?:127\.|10\.|192\.168|172\.1[6-9]\.|172\.2[0-9]\.|172\.3[01]\.).*',
-    'Honeynet': r'169.169.169.169',
-    'Windows SSDP': r'239.255.255.250',
-    'Azure VM Version': r'169.254.169.254',
-    'Azure Telemetry': r'168.63.129.16',
+    'Honeynet': r'169\.169\.169\.169',
+    'Windows SSDP': r'239\.255\.255\.250',
+    'Azure VM Version': r'169\.254\.169\.254',
+    'Azure Telemetry': r'168\.63\.129\.16',
     'Windows IGMP': r'224\..*',
+    'Local DHCP': r'255\.255\.255\.255',
 }
 
 SAFELIST_DROPPED = [
@@ -360,10 +362,15 @@ SAFELIST_URIS = {
 
     # Microsoft
     'Schemas': r'https?://schemas\.microsoft\.com(?:$|/.*)',
-    'Go Microsoft': r'(www\.)?go\.microsoft\.com*',
+    'Go Microsoft': r'https?://(www\.)?go\.microsoft\.com*',
+    'Microsoft Store': r'https?://displaycatalog\.md\.mp\.microsoft\.com*',
+    'Office Client': r'https?://officeclient\.microsoft\.com*',
 
     # Windows
     'Update': r'https?://ctldl\.windowsupdate\.com/.*',
+
+    # Ubuntu
+    'Archive': r'https?://ca\.archive\.ubuntu\.com/.*',
 
     # Office
     '2010 Word': r'https?://schemas\.microsoft\.com/office/word/2010/(wordml|wordprocessingCanvas|wordprocessingInk|wordprocessingGroup|wordprocessingDrawing)',

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -17,10 +17,10 @@ is_external: false
 licence_count: 0
 
 config:
-  # Cuckoo host specifications
-  remote_host_ip: 127.0.0.1
-  remote_host_port: 8090
-  auth_header_value: Bearer sample_api_token
+  # Cuckoo host specifications. A list of JSONs that each follow the format {"remote_host_ip": "<ip>", "remote_host_port": <integer port>, "api_key": "<api_key>"}
+  remote_host_details: [
+    {"remote_host_ip": "127.0.0.1", "remote_host_port": 8090, "api_key": "sample_api_token"},
+  ]
 
   # Strings representing images for specific submission to a VM pool of a certain image. See README.
   allowed_images: []
@@ -45,11 +45,6 @@ submission_params:
     name: analysis_timeout
     type: int
     value: 0
-
-  - default: true
-    name: generate_report
-    type: bool
-    value: true
 
   - default: ""
     name: dll_function
@@ -116,7 +111,8 @@ submission_params:
     type: int
     value: 134217728
 
-  # Used for development, when you want to send a file to a specific machine
+  # Used for development, when you want to send a file to a specific machine on a specific host. String format is
+  # "<host-ip>:<machine-name>" if more than one host exists. If only one host exists, then format can be either "<host-ip>:<machine-name>" or "<machine-name>"
   - default: ""
     name: specific_machine
     type: str


### PR DESCRIPTION
A few things in this PR:
- Pretend the cardinal emoji is a robin.
- Multiple Cuckoo hosts can be used by the service, as a way to avoid a single point of failure in any particular host or in the Cuckoo Distributed API.
- Removed generate_report flag, because it is assumed that everyone wants a report generated, otherwise pretty much nothing will get spat out by the service.
- Adding round-robin method for selecting a host based on the minimum queue size.