### PR TITLE
Adding service config variable for default analysis timeout

### DIFF
--- a/cuckoo/cuckoo_main.py
+++ b/cuckoo/cuckoo_main.py
@@ -1052,7 +1052,7 @@ class Cuckoo(ServiceBase):
             kwargs['timeout'] = timeout
         else:
             kwargs['enforce_timeout'] = False
-            kwargs['timeout'] = ANALYSIS_TIMEOUT
+            kwargs['timeout'] = self.config.get("default_analysis_timeout", ANALYSIS_TIMEOUT)
         arguments = self.request.get_param("arguments")
         # dump_memory = request.get_param("dump_memory")  # TODO: cloud Cuckoo implementation does not have
         #  dump_memory functionality

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -37,6 +37,7 @@ config:
   # Cuckoo Service specifications
   dedup_similar_percent: 40
   max_dll_exports_exec: 5
+  default_analysis_timeout: 150
 
   # Docker Container Limit
   max_report_size: 275000000


### PR DESCRIPTION
This should be a service config variable, not hard-coded into the service code.