### PR TITLE
Do not write encrypted buffers to files, they are redundant

### DIFF
--- a/cuckoo/cuckoo_result.py
+++ b/cuckoo/cuckoo_result.py
@@ -1531,9 +1531,13 @@ def _tag_and_describe_ioc_signature(
             process = so.get_process_by_command_line(ioc)
             if process:
                 so_sig.add_process_subject(**process.as_primitives())
-            sig_ioc_table = ResultTableSection("Command line IOCs")
+            command_line_iocs = "Command line IOCs"
+            if any(subsection.title_text == command_line_iocs for subsection in sig_res.subsections):
+                sig_ioc_table = next((subsection for subsection in sig_res.subsections if subsection.title_text == command_line_iocs))
+            else:
+                sig_ioc_table = ResultTableSection(command_line_iocs)
             _extract_iocs_from_text_blob(ioc, sig_ioc_table, so_sig)
-            if sig_ioc_table.body:
+            if sig_ioc_table not in sig_res.subsections and sig_ioc_table.body:
                 sig_res.add_subsection(sig_ioc_table)
     elif mark["category"] == "registry":
         so_sig.add_subject(registry=ioc)

--- a/cuckoo/cuckoo_result.py
+++ b/cuckoo/cuckoo_result.py
@@ -66,7 +66,6 @@ GUEST_LOSING_CONNNECTIVITY = 'Virtual Machine /status failed. This can indicate 
 GUEST_CANNOT_REACH_HOST = "it appears that this Virtual Machine hasn't been configured properly as the Cuckoo Host wasn't able to connect to the Guest."
 GUEST_LOST_CONNECTIVITY = 5
 SIGNATURES_SECTION_TITLE = "Signatures"
-ENCRYPTED_BUFFER_LIMIT = 25
 
 
 # noinspection PyBroadException
@@ -502,9 +501,10 @@ def process_network(network: Dict[str, Any], parent_result_section: ResultSectio
                             "InternetConnectA", {}) or network_call.get(
                             "WSAConnect", {}) or network_call.get(
                             "InternetOpenUrlA", {})
-                        if connect != {} and (connect.get("ip_address", "") == network_flow["dest_ip"] or connect.get(
-                            "hostname", "") == network_flow["dest_ip"]) and connect["port"] == network_flow[
-                                "dest_port"] or (network_flow["domain"] and network_flow["domain"] in connect.get("url", "")):
+                        if connect != {} and (
+                                connect.get("ip_address", "") == network_flow["dest_ip"] or connect.get("hostname", "") ==
+                                network_flow["dest_ip"]) and connect["port"] == network_flow["dest_port"] or (
+                                network_flow["domain"] and network_flow["domain"] in connect.get("url", "")):
                             network_flow["image"] = process_details["name"] + " (" + str(process) + ")"
                             network_flow["pid"] = process
                             break
@@ -621,7 +621,7 @@ def process_network(network: Dict[str, Any], parent_result_section: ResultSectio
     else:
         _process_non_http_traffic_over_http(network_res, unique_netflows)
 
-    _write_encrypted_buffers_to_file(task_id, process_map, network_res)
+    _extract_iocs_from_encrypted_buffers(process_map, network_res)
 
     if len(network_res.subsections) > 0:
         parent_result_section.add_subsection(network_res)
@@ -1151,6 +1151,7 @@ def process_decrypted_buffers(process_map: Dict[int, Dict[str, Any]], parent_res
         [buffer_res.add_row(TableRow(**buffer)) for buffer in buffer_body]
         if buffer_ioc_table.body:
             buffer_res.add_subsection(buffer_ioc_table)
+            buffer_res.set_heuristic(1006)
         parent_result_section.add_subsection(buffer_res)
 
 
@@ -1402,44 +1403,25 @@ def _write_injected_exe_to_file(task_id: int, marks: List[Dict[str, Any]]) -> No
         f.close()
 
 
-def _write_encrypted_buffers_to_file(task_id: int, process_map: Dict[int, Dict[str, Any]],
-                                     network_res: ResultSection) -> None:
+def _extract_iocs_from_encrypted_buffers(process_map: Dict[int, Dict[str, Any]],
+                                         network_res: ResultSection) -> None:
     """
-    Write temporary files containing encrypted buffers observed during network analysis
-    :param task_id: The ID of the Cuckoo Task
+    Extract IOCs from encrypted buffers observed during network analysis
     :param process_map: A map of process IDs to process names, network calls, and decrypted buffers
     :param network_res: The result section containing details about the network behaviour
     :return: None
     """
-    buffer_count = 0
-    buffers = set()
-    encrypted_buffer_result_section = ResultTextSection("Placeholder")
     encrypted_buffer_ioc_table = ResultTableSection(
-        "IOCs found in encrypted buffers")
-    for pid, process_details in process_map.items():
+        "IOCs found in encrypted buffers used in network calls")
+    for _, process_details in process_map.items():
         for network_call in process_details["network_calls"]:
             for api_call in BUFFER_API_CALLS:
                 if api_call in network_call:
-                    if buffer_count >= ENCRYPTED_BUFFER_LIMIT:
-                        continue
                     buffer = network_call[api_call]["buffer"]
                     _extract_iocs_from_text_blob(buffer, encrypted_buffer_ioc_table)
-                    encrypted_buffer_file_path = os.path.join(
-                        "/tmp", f"{task_id}_{pid}_encrypted_buffer_{buffer_count}.txt")
-                    buffers.add(encrypted_buffer_file_path)
-                    with open(encrypted_buffer_file_path, "wb") as f:
-                        f.write(buffer.encode())
-                    f.close()
-                    buffer_count += 1
-    if buffer_count > 0:
-        if encrypted_buffer_ioc_table.body:
-            encrypted_buffer_result_section.add_subsection(encrypted_buffer_ioc_table)
-        encrypted_buffer_result_section.title_text = f"{buffer_count} Encrypted Buffer(s) Found"
-        encrypted_buffer_result_section.set_heuristic(1006)
-        encrypted_buffer_result_section.add_line("The following buffers were found in network calls and "
-                                                 "extracted as files for further analysis:")
-        encrypted_buffer_result_section.add_lines(list(buffers))
-        network_res.add_subsection(encrypted_buffer_result_section)
+    if encrypted_buffer_ioc_table.body:
+        encrypted_buffer_ioc_table.set_heuristic(1006)
+        network_res.add_subsection(encrypted_buffer_ioc_table)
 
 
 def _tag_and_describe_generic_signature(

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -538,10 +538,10 @@ heuristics:
     description: Cuckoo detected non-HTTP traffic being made over HTTP ports (80, 443)
 
   - heur_id: 1006
-    name: Encrypted Buffer
+    name: IOC found in Buffer
     score: 500
     filetype: '*'
-    description: Cuckoo detected an encrypted buffer being transferred through a network call
+    description: Cuckoo detected an IOC found in a buffer, either encrypted or decrypted
 
   - heur_id: 1007
     name: Suspicious User Agent

--- a/tests/test_cuckoo_main.py
+++ b/tests/test_cuckoo_main.py
@@ -1568,7 +1568,6 @@ class TestCuckooMain:
         mocker.patch.object(Cuckoo, 'query_report', return_value=tar_report)
         mocker.patch.object(Cuckoo, '_extract_console_output', return_value=None)
         mocker.patch.object(Cuckoo, '_extract_injected_exes', return_value=None)
-        mocker.patch.object(Cuckoo, '_extract_encrypted_buffers', return_value=None)
         mocker.patch.object(Cuckoo, 'check_dropped', return_value=None)
         mocker.patch.object(Cuckoo, 'check_powershell', return_value=None)
         mocker.patch.object(Cuckoo, '_unpack_tar', return_value=None)
@@ -1758,19 +1757,6 @@ class TestCuckooMain:
         assert cuckoo_class_instance.artifact_list[0]["path"] == "/tmp/1_injected_memory_0.exe"
         assert cuckoo_class_instance.artifact_list[0]["name"] == "/tmp/1_injected_memory_0.exe"
         assert cuckoo_class_instance.artifact_list[0]["description"] == "Injected executable was found written to memory"
-        assert cuckoo_class_instance.artifact_list[0]["to_be_extracted"]
-
-    @staticmethod
-    def test_extract_encrypted_buffers(cuckoo_class_instance, dummy_request_class, mocker):
-        mocker.patch('os.listdir', return_value=["1_1_encrypted_buffer_0.txt"])
-        mocker.patch('os.path.isfile', return_value=True)
-        cuckoo_class_instance.request = dummy_request_class()
-        cuckoo_class_instance.artifact_list = []
-        task_id = 1
-        cuckoo_class_instance._extract_encrypted_buffers(task_id)
-        assert cuckoo_class_instance.artifact_list[0]["path"] == "/tmp/1_1_encrypted_buffer_0.txt"
-        assert cuckoo_class_instance.artifact_list[0]["name"] == "/tmp/1_1_encrypted_buffer_0.txt"
-        assert cuckoo_class_instance.artifact_list[0]["description"] == "Encrypted Buffer Observed in Network Traffic"
         assert cuckoo_class_instance.artifact_list[0]["to_be_extracted"]
 
     @staticmethod
@@ -2139,7 +2125,7 @@ class TestCuckooMain:
         number_of_files_in_tmp_pre_call = len(os.listdir(temp_dir))
         with open("/tmp/blah_console_output.txt", "w") as f:
             f.write("blah")
-        with open("/tmp/blah_encrypted_buffer_blah.txt", "w") as f:
+        with open("/tmp/blah_injected_memory_blah.exe", "w") as f:
             f.write("blah")
         number_of_files_in_tmp_post_write = len(os.listdir(temp_dir))
         assert number_of_files_in_tmp_post_write == number_of_files_in_tmp_pre_call + 2


### PR DESCRIPTION
After analyzing the results of ~4000 submissions where encrypted buffers were written to files and extracted, ~30000 encrypted buffers were written to file (obviously a large ratio of submissions to encrypted buffers). These extracted files did not score  by any service that we manage, therefore they would only be useful for tagging. Currently Cuckoo looks for domains, IPs, and URIs in these buffers. The number of unique tags that are extracted by other services for these files is ~30. Out of ~30000 files, for ~30 tags to be extracted, that is not enough to warrant their extraction, especially since ~25 are not useful.