### PR TITLE
Making it optional to include the dump_memory param

### DIFF
--- a/cuckoo/cuckoo_main.py
+++ b/cuckoo/cuckoo_main.py
@@ -1117,7 +1117,7 @@ class Cuckoo(ServiceBase):
             kwargs['enforce_timeout'] = False
             kwargs['timeout'] = self.config.get("default_analysis_timeout_in_seconds", ANALYSIS_TIMEOUT)
         arguments = self.request.get_param("arguments")
-        dump_memory = self.request.get_param("dump_memory")
+        dump_memory = self._safely_get_param("dump_memory")
         no_monitor = self.request.get_param("no_monitor")
 
         # If the user didn't select no_monitor, but at the service level we want no_monitor on Windows 10x64, then:


### PR DESCRIPTION
So that we can delete it from the submission parameters in the UI if memory dumps are not supported